### PR TITLE
Make Text::VCardFast compile and test OK on Windows

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,0 +1,35 @@
+name: linux
+
+on:
+  push:
+    branches:
+      - '*'
+    tags-ignore:
+      - '*'
+  pull_request:
+
+jobs:
+  perl:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        perl-version:
+          - '5.14'
+          - 'latest'
+
+    container:
+      image: perl:${{ matrix.perl-version }}
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: perl -V
+        run: perl -V
+      - name: Install Dependencies
+        run: cpanm --quiet --notest --installdeps .
+      - name: Run Tests
+        run: |
+          perl Makefile.PL
+          make test

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,29 @@
+name: windows
+
+on:
+  push:
+    branches:
+      - '*'
+    tags-ignore:
+      - '*'
+  pull_request:
+
+jobs:
+  perl:
+
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Perl
+        run: |
+          choco install strawberryperl
+          echo "C:\strawberry\c\bin;C:\strawberry\perl\site\bin;C:\strawberry\perl\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      - name: perl -V
+        run: perl -V
+      - name: Install Dependencies
+        run: cpanm --quiet --notest --installdeps .
+      - name: Run Tests
+        run: |
+          perl Makefile.PL
+          make test

--- a/vparse.c
+++ b/vparse.c
@@ -46,9 +46,29 @@ static void _buf_ensure(struct buf *buf, size_t n)
     buf->alloc = newalloc;
 }
 
+#if defined(WIN32)
+static char *mystrndup(const char *s, size_t n)
+{
+    size_t len = strlen(s);
+    char *new;
+
+    if (n < len)
+        len = n;
+
+    new = (char *) malloc(len + 1);
+    if (new == NULL)
+        return NULL;
+
+    new[len] = '\0';
+    return (char *) memcpy (new, s, len); /* NOLINT */
+}
+#else
+#define mystrndup(s, n) strndup(s, n)
+#endif
+
 static char *buf_dup_cstring(struct buf *buf)
 {
-    char *ret = strndup(buf->s, buf->len);
+    char *ret = mystrndup(buf->s, buf->len);
     /* more space efficient than returning overlength buffers, and
      * you would just wind up mallocing another buffer anyway */
     buf->len = 0;


### PR DESCRIPTION
This PR is a modernized alternative to #4.

The PR adds
- GitHub Actions for Linux and Windows.
- a mystrndup() function for Windows.

The [C23](https://en.wikipedia.org/wiki/C23_(C_standard_revision)) standard will add strndup() to C. The mystrndup() function will never conflict with the strndup() declaration.